### PR TITLE
Add annotation attributes, COCO import, and image switch workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "napari-SAM4IS"
-version = "0.1.2"
+version = "0.1.3"
 description = "Create annotations for instance segmentation using Segment Anything models"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/napari_sam4is/_utils.py
+++ b/src/napari_sam4is/_utils.py
@@ -261,7 +261,17 @@ def load_json(json_path):
                     len(sub),
                 )
                 continue
-            coords = np.array(sub[::-1], dtype=float).reshape(-1, 2)
+            try:
+                coords = np.array(sub[::-1], dtype=float).reshape(-1, 2)
+            except (ValueError, TypeError) as exc:
+                logger.warning(
+                    "Skipping sub-polygon in annotation "
+                    "(id=%s, index=%d): %s",
+                    ann_id,
+                    i,
+                    exc,
+                )
+                continue
             sub_polygons.append(coords)
 
         if len(sub_polygons) > 1:

--- a/src/napari_sam4is/_widget.py
+++ b/src/napari_sam4is/_widget.py
@@ -1542,7 +1542,7 @@ class SAMWidget(QWidget):
         """
         try:
             result = load_json(json_path)
-        except (json.JSONDecodeError, KeyError, TypeError) as e:
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
             print(f"Failed to load JSON: {e}")
             return False
 

--- a/src/napari_sam4is/_widget.py
+++ b/src/napari_sam4is/_widget.py
@@ -233,13 +233,13 @@ class SAMWidget(QWidget):
         self._attr_layout.addWidget(self._uncertain_checkbox)
 
         self._review_btn_layout = QHBoxLayout()
-        self._review_selected_btn = QPushButton("Review Selected")
-        self._review_selected_btn.clicked.connect(self._review_selected)
-        self._review_selected_btn.setEnabled(False)
-        self._review_btn_layout.addWidget(self._review_selected_btn)
-        self._review_all_btn = QPushButton("Review All")
-        self._review_all_btn.clicked.connect(self._review_all)
-        self._review_btn_layout.addWidget(self._review_all_btn)
+        self._accept_selected_btn = QPushButton("Accept Selected")
+        self._accept_selected_btn.clicked.connect(self._accept_selected)
+        self._accept_selected_btn.setEnabled(False)
+        self._review_btn_layout.addWidget(self._accept_selected_btn)
+        self._accept_all_btn = QPushButton("Accept All")
+        self._accept_all_btn.clicked.connect(self._accept_all)
+        self._review_btn_layout.addWidget(self._accept_all_btn)
         self._attr_layout.addLayout(self._review_btn_layout)
 
         self._attr_status_label = QLabel("No annotation selected")
@@ -653,7 +653,7 @@ class SAMWidget(QWidget):
         # Enable controls
         self._unclear_checkbox.setEnabled(True)
         self._uncertain_checkbox.setEnabled(True)
-        self._review_selected_btn.setEnabled(True)
+        self._accept_selected_btn.setEnabled(True)
 
         # Unclear
         unclear_vals = features.loc[selected, "unclear"]
@@ -691,7 +691,7 @@ class SAMWidget(QWidget):
         self._uncertain_checkbox.setEnabled(False)
         self._uncertain_checkbox.blockSignals(False)
 
-        self._review_selected_btn.setEnabled(False)
+        self._accept_selected_btn.setEnabled(False)
         self._attr_status_label.setText("No annotation selected")
 
     def _set_tristate_checkbox(self, checkbox, values):
@@ -759,8 +759,8 @@ class SAMWidget(QWidget):
         if selected:
             layer.features.loc[selected, attr_name] = value
 
-    def _review_selected(self):
-        """Mark selected annotations as reviewed."""
+    def _accept_selected(self):
+        """Mark selected annotations as accepted."""
         output_name = self._shapes_layer_selection.currentText()
         if not output_name:
             return
@@ -778,8 +778,8 @@ class SAMWidget(QWidget):
         layer.features.loc[selected, "reviewed_at"] = now
         self._on_output_selection_changed()
 
-    def _review_all(self):
-        """Mark all annotations as reviewed."""
+    def _accept_all(self):
+        """Mark all annotations as accepted."""
         output_name = self._shapes_layer_selection.currentText()
         if not output_name:
             return
@@ -795,7 +795,7 @@ class SAMWidget(QWidget):
         layer.features["review_status"] = "approved"
         layer.features["reviewed_at"] = now
         self._on_output_selection_changed()
-        print(f"Reviewed all {len(layer.features)} annotations")
+        print(f"Accepted all {len(layer.features)} annotations")
 
     # --- Class Management Methods ---
 


### PR DESCRIPTION
## Summary

- **Annotation attributes**: Add per-shape `unclear`, `uncertain`, `review_status`, `reviewed_at` fields stored in layer features and exported to COCO JSON `attributes`
- **COCO JSON import**: Load annotations from single-image COCO JSON files with roundtrip fidelity (Save → Load preserves polygons, classes, and attributes)
- **Image switch workflow**: When switching images via the ComboBox, prompt to save unsaved annotations → auto-clear output layer → auto-load annotations for the new image
- **Tristate checkbox fix**: Normalize `PartiallyChecked` → `Checked` on user click to prevent Qt implicit tri-state cycling
- **ComboBox duplication fix**: Block signals during ComboBox rebuild to prevent cascading updates; explicitly invoke handlers when effective selection changes
- **Robustness**: Harden `load_json` against malformed COCO files (RLE, odd coords, multi-image), handle deleted image layers gracefully

## Test plan

- [x] All 20 existing tests pass (`uv run pytest src/napari_sam4is/_tests/test_widget.py -v`)
- [x] Lint clean (`uv run ruff check src/ && uv run black --check src/`)
- [x] Manual: Load two images → annotate image A → switch to image B → verify save dialog appears (Save/Discard/Cancel)
- [x] Manual: Save → verify JSON written for image A → output cleared → image B auto-loads if JSON exists
- [x] Manual: Discard → output cleared → image B auto-loads
- [x] Manual: Cancel → stays on image A with annotations intact
- [x] Manual: Switch back to image A → annotations auto-load from saved JSON
- [x] Manual: Delete image layer while annotations exist → verify discard notification
- [x] Manual: Select multiple annotations with mixed unclear → verify checkbox shows partial state → click → becomes Checked
- [x] Manual: Accept Selected / Accept All → verify review_status and reviewed_at update