### PR TITLE
Add CJK font support for Japanese class names (v0.1.6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ venv/
 
 CLAUDE.md
 .claude/
+plans/
+uv.lock

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,4 +18,4 @@ abstract: >-
   napari plugin for instance and semantic segmentation
   annotation using Segment Anything Model (SAM)
 license: Apache-2.0
-version: 0.1.5
+version: 0.1.6

--- a/README.ja.md
+++ b/README.ja.md
@@ -140,6 +140,19 @@ pip install -e .
 [Apache Software License 2.0] ライセンスの下で配布されています。
 「napari-SAM4IS」はフリーかつオープンソースのソフトウェアです。
 
+## Citation
+
+napari-SAM4IS を研究に使用した場合は、以下の形式で引用してください：
+
+```bibtex
+@software{kawai_napari_sam4is,
+  author  = {Kawai, Hiroki},
+  title   = {napari-SAM4IS},
+  url     = {https://github.com/hiroalchem/napari-SAM4IS},
+  license = {Apache-2.0},
+}
+```
+
 ## Issues
 
 問題が発生した場合は、詳細な説明とともに [Issue を報告](https://github.com/hiroalchem/napari-SAM4IS/issues) してください。

--- a/README.md
+++ b/README.md
@@ -148,6 +148,19 @@ the coverage at least stays the same before you submit a pull request.
 Distributed under the terms of the [Apache Software License 2.0] license,
 "napari-SAM4IS" is free and open source software
 
+## Citation
+
+If you use napari-SAM4IS in your research, please cite it:
+
+```bibtex
+@software{kawai_napari_sam4is,
+  author  = {Kawai, Hiroki},
+  title   = {napari-SAM4IS},
+  url     = {https://github.com/hiroalchem/napari-SAM4IS},
+  license = {Apache-2.0},
+}
+```
+
 ## Issues
 
 If you encounter any problems, please [file an issue] along with a detailed description.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ napari-SAM4IS = "napari_sam4is:napari.yaml"
 where = ["src"]
 
 [tool.setuptools.package-data]
-"*" = ["*.yaml"]
+"*" = ["*.yaml", "fonts/*.ttf"]
 
 [tool.black]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "napari-SAM4IS"
-version = "0.1.5"
+version = "0.1.6"
 description = "Create annotations for instance segmentation using Segment Anything models"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ napari-SAM4IS = "napari_sam4is:napari.yaml"
 where = ["src"]
 
 [tool.setuptools.package-data]
-"*" = ["*.yaml", "fonts/*.ttf"]
+"*" = ["*.yaml", "fonts/*.ttf", "fonts/*.txt"]
 
 [tool.black]
 line-length = 79

--- a/src/napari_sam4is/__init__.py
+++ b/src/napari_sam4is/__init__.py
@@ -26,9 +26,11 @@ def _patch_vispy_cjk_font():
     """Register NotoSansJP with vispy and wrap _load_glyph for CJK fallback."""
     try:
         import sys as _sys2
+
+        import vispy.util.fonts._triage  # noqa: F401
+
         # Import modules so they appear in sys.modules, then access via sys.modules
         import vispy.util.fonts._vispy_fonts  # noqa: F401
-        import vispy.util.fonts._triage  # noqa: F401
         _vf_mod = _sys2.modules["vispy.util.fonts._vispy_fonts"]
         _triage_mod = _sys2.modules["vispy.util.fonts._triage"]
 
@@ -72,9 +74,9 @@ def _patch_vispy_cjk_font():
             import vispy.visuals.text.text  # noqa: F401
             _text_mod = _sys2.modules["vispy.visuals.text.text"]
             _text_mod._load_glyph = _cjk_load_glyph
-        except Exception:
+        except (ImportError, KeyError, AttributeError):
             pass
-    except Exception as _e:
+    except (ImportError, ModuleNotFoundError, KeyError, AttributeError, TypeError) as _e:
         import warnings
         warnings.warn(
             f"napari-SAM4IS: CJK font patch failed ({_e}). "

--- a/src/napari_sam4is/__init__.py
+++ b/src/napari_sam4is/__init__.py
@@ -90,10 +90,10 @@ if _os.path.isfile(_NOTO_TTF):
 
 # ----------------------
 
-from collections.abc import Collection
+from collections.abc import Collection  # noqa: E402
 
-from napari.layers.shapes.shapes import Shapes
-from napari.utils.events.containers import Selection
+from napari.layers.shapes.shapes import Shapes  # noqa: E402
+from napari.utils.events.containers import Selection  # noqa: E402
 
 # Add replace_selection to Selection class if missing (version guard)
 if not hasattr(Selection, "replace_selection"):

--- a/src/napari_sam4is/__init__.py
+++ b/src/napari_sam4is/__init__.py
@@ -7,6 +7,87 @@
 # Note: This patch is applied conditionally based on the presence of the
 # replace_selection method, making it compatible with both affected versions
 # (e.g., 0.6.6) and future versions where the bug may be fixed.
+
+# --- CJK font patch ---
+# vispy's default OpenSans font does not contain CJK glyphs, causing Japanese
+# class names to render as tofu squares on the Shapes layer. We register the
+# bundled NotoSansJP font as a vispy-internal font and wrap _load_glyph so that
+# CJK characters (U+3000 and above) are rendered with NotoSansJP while all
+# other characters continue to use the default OpenSans font.
+import os as _os
+import sys as _sys
+
+_FONTS_DIR = _os.path.join(_os.path.dirname(__file__), "fonts")
+_NOTO_FACE = "NotoSansJP"
+_NOTO_TTF = _os.path.join(_FONTS_DIR, "NotoSansJP-Regular.ttf")
+
+
+def _patch_vispy_cjk_font():
+    """Register NotoSansJP with vispy and wrap _load_glyph for CJK fallback."""
+    try:
+        import sys as _sys2
+        # Import modules so they appear in sys.modules, then access via sys.modules
+        import vispy.util.fonts._vispy_fonts  # noqa: F401
+        import vispy.util.fonts._triage  # noqa: F401
+        _vf_mod = _sys2.modules["vispy.util.fonts._vispy_fonts"]
+        _triage_mod = _sys2.modules["vispy.util.fonts._triage"]
+
+        # Register NotoSansJP as a vispy built-in font so _load_font can find it
+        _orig_vispy_fonts = _vf_mod._vispy_fonts
+        if _NOTO_FACE not in _orig_vispy_fonts:
+            _vf_mod._vispy_fonts = _orig_vispy_fonts + (_NOTO_FACE,)
+
+        # Override _get_vispy_font_filename to return our bundled TTF for NotoSansJP
+        _orig_get_filename = _vf_mod._get_vispy_font_filename
+
+        def _patched_get_filename(face, bold, italic):
+            if face == _NOTO_FACE:
+                return _NOTO_TTF
+            return _orig_get_filename(face, bold, italic)
+
+        _vf_mod._get_vispy_font_filename = _patched_get_filename
+
+        # Also patch the platform-specific module's reference to _get_vispy_font_filename
+        if _sys.platform == "darwin":
+            import vispy.util.fonts._quartz  # noqa: F401
+            _platform_mod = _sys2.modules["vispy.util.fonts._quartz"]
+        else:
+            import vispy.util.fonts._freetype  # noqa: F401
+            _platform_mod = _sys2.modules["vispy.util.fonts._freetype"]
+
+        _platform_mod._get_vispy_font_filename = _patched_get_filename
+        _platform_mod._vispy_fonts = _vf_mod._vispy_fonts
+        _orig_load_glyph = _platform_mod._load_glyph
+
+        def _cjk_load_glyph(f, char, glyphs_dict):
+            """Use NotoSansJP for CJK characters, default font otherwise."""
+            if ord(char) >= 0x3000:
+                f = dict(f, face=_NOTO_FACE)
+            _orig_load_glyph(f, char, glyphs_dict)
+
+        # Patch the triage module (public API used by TextureFont)
+        _triage_mod._load_glyph = _cjk_load_glyph
+        # Patch the reference in the text visual module (used by TextureFont._load_char)
+        try:
+            import vispy.visuals.text.text  # noqa: F401
+            _text_mod = _sys2.modules["vispy.visuals.text.text"]
+            _text_mod._load_glyph = _cjk_load_glyph
+        except Exception:
+            pass
+    except Exception as _e:
+        import warnings
+        warnings.warn(
+            f"napari-SAM4IS: CJK font patch failed ({_e}). "
+            "Japanese class names may not display correctly on layers.",
+            stacklevel=2,
+        )
+
+
+if _os.path.isfile(_NOTO_TTF):
+    _patch_vispy_cjk_font()
+
+# ----------------------
+
 from collections.abc import Collection
 
 from napari.layers.shapes.shapes import Shapes

--- a/src/napari_sam4is/_utils.py
+++ b/src/napari_sam4is/_utils.py
@@ -208,7 +208,7 @@ def load_json(json_path):
             "attributes": dict or None
         - "image_info": dict with "file_name", "height", "width"
     """
-    with open(json_path) as f:
+    with open(json_path, encoding="utf-8") as f:
         coco = json.load(f)
 
     images = coco.get("images", [])

--- a/src/napari_sam4is/_widget.py
+++ b/src/napari_sam4is/_widget.py
@@ -993,7 +993,7 @@ class SAMWidget(QWidget):
         )
         if not fname:
             return
-        with open(fname) as f:
+        with open(fname, encoding="utf-8") as f:
             data = yaml.safe_load(f)
         if not isinstance(data, dict) or "names" not in data:
             print("Invalid class file format")
@@ -1064,8 +1064,13 @@ class SAMWidget(QWidget):
         if names:
             class_data = {"names": names}
             path = os.path.join(directory, "class.yaml")
-            with open(path, "w") as f:
-                yaml.dump(class_data, f, default_flow_style=False)
+            with open(path, "w", encoding="utf-8") as f:
+                yaml.dump(
+                    class_data,
+                    f,
+                    default_flow_style=False,
+                    allow_unicode=True,
+                )
 
     def _load_model(self):
         if self._use_api_checkbox.isChecked():
@@ -1643,8 +1648,8 @@ class SAMWidget(QWidget):
             category_ids=category_ids,
             attributes_list=attributes_list,
         )
-        with open(output_path, "w") as f:
-            json.dump(data, f)
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False)
 
         self._save_class_yaml(os.path.dirname(image_path))
         print("saved")

--- a/src/napari_sam4is/fonts/OFL.txt
+++ b/src/napari_sam4is/fonts/OFL.txt
@@ -1,0 +1,93 @@
+Copyright 2014-2021 Adobe (http://www.adobe.com/), with Reserved Font Name 'Source'
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/src/napari_sam4is/fonts/OFL.txt
+++ b/src/napari_sam4is/fonts/OFL.txt
@@ -1,8 +1,9 @@
-This Font Software is licensed under the SIL Open Font License,
-Version 1.1.
+Copyright 2014-2021 Adobe (http://www.adobe.com/), with Reserved Font Name 'Source'
 
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:
-http://scripts.sil.org/OFL
+https://openfontlicense.org
+
 
 -----------------------------------------------------------
 SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
@@ -10,19 +11,19 @@ SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
 
 PREAMBLE
 The goals of the Open Font License (OFL) are to stimulate worldwide
-development of collaborative font projects, to support the font
-creation efforts of academic and linguistic communities, and to
-provide a free and open framework in which fonts may be shared and
-improved in partnership with others.
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
 
 The OFL allows the licensed fonts to be used, studied, modified and
 redistributed freely as long as they are not sold by themselves. The
-fonts, including any derivative works, can be bundled, embedded,
+fonts, including any derivative works, can be bundled, embedded, 
 redistributed and/or sold with any software provided that any reserved
 names are not used by derivative works. The fonts and derivatives,
 however, cannot be released under any other type of license. The
-requirement for fonts to remain under this license does not apply to
-any document created using the fonts or their derivatives.
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
 
 DEFINITIONS
 "Font Software" refers to the set of files released by the Copyright
@@ -32,25 +33,25 @@ include source files, build scripts and documentation.
 "Reserved Font Name" refers to any names specified as such after the
 copyright statement(s).
 
-"Original Version" refers to the collection of Font Software
-components as distributed by the Copyright Holder(s).
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
 
-"Modified Version" refers to any derivative made by adding to,
-deleting, or substituting -- in part or in whole -- any of the
-components of the Original Version, by changing formats or by porting
-the Font Software to a new environment.
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
 
 "Author" refers to any designer, engineer, programmer, technical
 writer or other person who contributed to the Font Software.
 
 PERMISSION & CONDITIONS
 Permission is hereby granted, free of charge, to any person obtaining
-a copy of the Font Software, to use, study, copy, merge, embed,
-modify, redistribute, and sell modified and unmodified copies of the
-Font Software, subject to the following conditions:
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
 
-1) Neither the Font Software nor any of its individual components, in
-Original or Modified Versions, may be sold by itself.
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
 
 2) Original or Modified Versions of the Font Software may be bundled,
 redistributed and/or sold with any software, provided that each copy
@@ -60,9 +61,9 @@ in the appropriate machine-readable metadata fields within text or
 binary files as long as those fields can be easily viewed by the user.
 
 3) No Modified Version of the Font Software may use the Reserved Font
-Name(s) unless explicit written permission is granted by the
-corresponding Copyright Holder. This restriction only applies to the
-primary font name as presented to the users.
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
 
 4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
 Software shall not be used to promote, endorse or advertise any
@@ -73,8 +74,8 @@ permission.
 5) The Font Software, modified or unmodified, in part or in whole,
 must be distributed entirely under this license, and must not be
 distributed under any other license. The requirement for fonts to
-remain under this license does not apply to any document created using
-the Font Software.
+remain under this license does not apply to any document created
+using the Font Software.
 
 TERMINATION
 This license becomes null and void if any of the above conditions are

--- a/src/napari_sam4is/fonts/OFL.txt
+++ b/src/napari_sam4is/fonts/OFL.txt
@@ -1,9 +1,8 @@
-Copyright 2014-2021 Adobe (http://www.adobe.com/), with Reserved Font Name 'Source'
+This Font Software is licensed under the SIL Open Font License,
+Version 1.1.
 
-This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:
-https://scripts.sil.org/OFL
-
+http://scripts.sil.org/OFL
 
 -----------------------------------------------------------
 SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
@@ -11,19 +10,19 @@ SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
 
 PREAMBLE
 The goals of the Open Font License (OFL) are to stimulate worldwide
-development of collaborative font projects, to support the font creation
-efforts of academic and linguistic communities, and to provide a free and
-open framework in which fonts may be shared and improved in partnership
-with others.
+development of collaborative font projects, to support the font
+creation efforts of academic and linguistic communities, and to
+provide a free and open framework in which fonts may be shared and
+improved in partnership with others.
 
 The OFL allows the licensed fonts to be used, studied, modified and
 redistributed freely as long as they are not sold by themselves. The
-fonts, including any derivative works, can be bundled, embedded, 
+fonts, including any derivative works, can be bundled, embedded,
 redistributed and/or sold with any software provided that any reserved
 names are not used by derivative works. The fonts and derivatives,
 however, cannot be released under any other type of license. The
-requirement for fonts to remain under this license does not apply
-to any document created using the fonts or their derivatives.
+requirement for fonts to remain under this license does not apply to
+any document created using the fonts or their derivatives.
 
 DEFINITIONS
 "Font Software" refers to the set of files released by the Copyright
@@ -33,25 +32,25 @@ include source files, build scripts and documentation.
 "Reserved Font Name" refers to any names specified as such after the
 copyright statement(s).
 
-"Original Version" refers to the collection of Font Software components as
-distributed by the Copyright Holder(s).
+"Original Version" refers to the collection of Font Software
+components as distributed by the Copyright Holder(s).
 
-"Modified Version" refers to any derivative made by adding to, deleting,
-or substituting -- in part or in whole -- any of the components of the
-Original Version, by changing formats or by porting the Font Software to a
-new environment.
+"Modified Version" refers to any derivative made by adding to,
+deleting, or substituting -- in part or in whole -- any of the
+components of the Original Version, by changing formats or by porting
+the Font Software to a new environment.
 
 "Author" refers to any designer, engineer, programmer, technical
 writer or other person who contributed to the Font Software.
 
 PERMISSION & CONDITIONS
 Permission is hereby granted, free of charge, to any person obtaining
-a copy of the Font Software, to use, study, copy, merge, embed, modify,
-redistribute, and sell modified and unmodified copies of the Font
-Software, subject to the following conditions:
+a copy of the Font Software, to use, study, copy, merge, embed,
+modify, redistribute, and sell modified and unmodified copies of the
+Font Software, subject to the following conditions:
 
-1) Neither the Font Software nor any of its individual components,
-in Original or Modified Versions, may be sold by itself.
+1) Neither the Font Software nor any of its individual components, in
+Original or Modified Versions, may be sold by itself.
 
 2) Original or Modified Versions of the Font Software may be bundled,
 redistributed and/or sold with any software, provided that each copy
@@ -61,9 +60,9 @@ in the appropriate machine-readable metadata fields within text or
 binary files as long as those fields can be easily viewed by the user.
 
 3) No Modified Version of the Font Software may use the Reserved Font
-Name(s) unless explicit written permission is granted by the corresponding
-Copyright Holder. This restriction only applies to the primary font name as
-presented to the users.
+Name(s) unless explicit written permission is granted by the
+corresponding Copyright Holder. This restriction only applies to the
+primary font name as presented to the users.
 
 4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
 Software shall not be used to promote, endorse or advertise any
@@ -74,8 +73,8 @@ permission.
 5) The Font Software, modified or unmodified, in part or in whole,
 must be distributed entirely under this license, and must not be
 distributed under any other license. The requirement for fonts to
-remain under this license does not apply to any document created
-using the Font Software.
+remain under this license does not apply to any document created using
+the Font Software.
 
 TERMINATION
 This license becomes null and void if any of the above conditions are


### PR DESCRIPTION
## Summary

- Bundle `NotoSansJP-Regular.ttf` (SIL Open Font License) in `src/napari_sam4is/fonts/`
- Monkey-patch vispy's `_load_glyph` so CJK characters (U+3000+) render with Noto Sans JP; ASCII/Latin continues using OpenSans
- Add `fonts/*.ttf` to `package-data` in `pyproject.toml` so the font is included in wheel/sdist
- Update `.gitignore`: add `plans/` and `uv.lock`
- Add Citation section to README (English & Japanese) and update `CITATION.cff`
- Bump version to 0.1.6

**Fixes**: Japanese class names appearing as tofu squares (□□) on the Accepted shapes layer.

## Test plan

- [x] Add a Japanese class name (e.g. `犬`, `猫`) in Class Management
- [x] Accept a prediction — confirm the class label renders correctly on the Accepted shapes layer
- [x] Confirm English class names still render normally with OpenSans
- [x] Confirm installed package includes `napari_sam4is/fonts/NotoSansJP-Regular.ttf`