### PR TITLE
Fix box prompt sensitivity to drawing direction (#19)

### DIFF
--- a/src/napari_sam4is/_tests/test_widget.py
+++ b/src/napari_sam4is/_tests/test_widget.py
@@ -1517,16 +1517,16 @@ def test_set_input_box_normalizes_drawing_direction(make_napari_viewer):
     viewer.add_image(np.random.random((100, 100)))
     widget = SAMWidget(viewer)
 
-    # Rectangle x in [10, 50], y in [20, 60]; vertices are (row=y, col=x).
+    # Rectangle x in [10.5, 50.5], y in [20.5, 60.5]; verts are (row=y, col=x).
     corners = [
-        [20, 10],  # top-left
-        [20, 50],  # top-right
-        [60, 50],  # bottom-right
-        [60, 10],  # bottom-left
+        [20.5, 10.5],  # top-left
+        [20.5, 50.5],  # top-right
+        [60.5, 50.5],  # bottom-right
+        [60.5, 10.5],  # bottom-left
     ]
     # Each start corner is a different drag direction, same rectangle.
     for start in range(4):
         verts = np.array(corners[start:] + corners[:start])
         widget._sam_box_layer.data = [verts]
         widget._set_input_box_from_sam_box_layer()
-        assert list(widget._input_box) == [10, 20, 50, 60]
+        assert list(widget._input_box) == [10.5, 20.5, 50.5, 60.5]

--- a/src/napari_sam4is/_tests/test_widget.py
+++ b/src/napari_sam4is/_tests/test_widget.py
@@ -1509,3 +1509,24 @@ def test_accept_multi_masks_iou_zero(make_napari_viewer):
     n = widget._accept_multi_masks(m1, "1: cell")
     # No filtering, so should be accepted
     assert n == 1
+
+
+def test_set_input_box_normalizes_drawing_direction(make_napari_viewer):
+    """Box prompt is direction-independent (issue #19)."""
+    viewer = make_napari_viewer()
+    viewer.add_image(np.random.random((100, 100)))
+    widget = SAMWidget(viewer)
+
+    # Rectangle x in [10, 50], y in [20, 60]; vertices are (row=y, col=x).
+    corners = [
+        [20, 10],  # top-left
+        [20, 50],  # top-right
+        [60, 50],  # bottom-right
+        [60, 10],  # bottom-left
+    ]
+    # Each start corner is a different drag direction, same rectangle.
+    for start in range(4):
+        verts = np.array(corners[start:] + corners[:start])
+        widget._sam_box_layer.data = [verts]
+        widget._set_input_box_from_sam_box_layer()
+        assert list(widget._input_box) == [10, 20, 50, 60]

--- a/src/napari_sam4is/_widget.py
+++ b/src/napari_sam4is/_widget.py
@@ -1987,9 +1987,7 @@ class SAMWidget(QWidget):
         """Store SAM-Box rectangle as normalized [x1, y1, x2, y2]."""
         coords = np.asarray(self._sam_box_layer.data[0])
         ys, xs = coords[:, 0], coords[:, 1]
-        self._input_box = np.array(
-            [int(xs.min()), int(ys.min()), int(xs.max()), int(ys.max())]
-        )
+        self._input_box = np.array([xs.min(), ys.min(), xs.max(), ys.max()])
 
     def _reject_all_boxes(self, layer):
         self._sam_box_layer.data = []

--- a/src/napari_sam4is/_widget.py
+++ b/src/napari_sam4is/_widget.py
@@ -1978,16 +1978,18 @@ class SAMWidget(QWidget):
                     self._on_image_layer_changed(None)
             else:
                 pass
-            coords = self._sam_box_layer.data[0]
-            y1 = int(coords[0][0])
-            x1 = int(coords[0][1])
-            y2 = int(coords[2][0])
-            x2 = int(coords[2][1])
-            print(f"x1 = {x1}, y1 = {y1}, x2 = {x2}, y2 = {y2}")
-            self._input_box = np.array([x1, y1, x2, y2])
+            self._set_input_box_from_sam_box_layer()
             self._create_input_point()
             self._predict()
             self._sam_box_layer.data = []
+
+    def _set_input_box_from_sam_box_layer(self):
+        """Store SAM-Box rectangle as normalized [x1, y1, x2, y2]."""
+        coords = np.asarray(self._sam_box_layer.data[0])
+        ys, xs = coords[:, 0], coords[:, 1]
+        self._input_box = np.array(
+            [int(xs.min()), int(ys.min()), int(xs.max()), int(ys.max())]
+        )
 
     def _reject_all_boxes(self, layer):
         self._sam_box_layer.data = []


### PR DESCRIPTION
Closes #19.

Fixes segmentation results changing depending on the direction the box prompt is drawn.

## Cause
`_on_sam_box_created` read coordinates from the rectangle's fixed vertices `coords[0]`/`coords[2]`, so depending on the drawing direction it could pass an un-normalized box with `x1>x2` / `y1>y2` (negative width/height) to downstream code.

## Fix
Added `_set_input_box_from_sam_box_layer`, which normalizes to `[x_min, y_min, x_max, y_max]` via min/max over all vertices, and call it from the callback. This matches the existing `_get_selected_exemplar_boxes` approach. Added a test covering all four drawing directions.

## Note
Forcing the SAM-Box layer into rectangle mode (shape-mode enforcement) is out of scope here, since min/max returns the bounding box of any shape, so this fix is shape-independent.